### PR TITLE
Lowecase all headers keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,6 +197,15 @@ class Response {
     this.data = res.responseText || res.response;
     this.status = res.status
     this.statusText = res.statusText
+    
+    /* lowecase all headers keys to be consistent with Axios */
+    if ('headers' in res) {
+      let newHeaders = {};
+      for (let header in res.headers) {
+        newHeaders[header.toLowerCase()] = res.headers[header];
+      }
+      res.headers = newHeaders;
+    }
     this.headers = res.headers
     this.request = req
     this.code = res.code


### PR DESCRIPTION
[Axios lowercases all incoming headers' keys at parsing stage](https://github.com/mzabriskie/axios/blob/b8f6f5049cf3da8126a184b6b270316402b5b374/lib/helpers/parseHeaders.js#L28), and since mocked responses don't go through axios'es parsing stage, capitilazied header keys can reach the API end, introducing inconsistent headers when testing vs in production.

In real life: 

Server: 
```
headers: { Content-Type: text/html }
```

Axios:
```
headers: { 'content-type': 'text/html' }
```

With moxios

Mock server: 
```
headers: { Content-Type: text/html }
```

Axios:
```
headers: { 'Content-Type': 'text/html' }
```

Introducing:
```
response.headers['content-type'] === undefined
```
